### PR TITLE
Use netip.Addr instead of net.IP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -12,7 +12,6 @@ jobs:
         working-directory: test
     strategy:
       matrix:
-        go-version: [1.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ jobs:
   unit_test:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"os/signal"
 	"syscall"
@@ -32,8 +33,8 @@ func main() {
 		lis net.Listener
 		err error
 	)
-	remote := net.ParseIP(*remoteAddress)
-	local := net.ParseIP(*localAddress)
+	remote := netip.MustParseAddr(*remoteAddress)
+	local := netip.MustParseAddr(*localAddress)
 	if len(*bindAddr) > 0 {
 		lc := &net.ListenConfig{}
 		if len(*md5) > 0 {
@@ -42,12 +43,7 @@ func main() {
 				var seterr error
 				err := c.Control(func(fdPtr uintptr) {
 					fd := int(fdPtr)
-					prefixLen := uint8(32)
-					if remote.To4() == nil {
-						prefixLen = 128
-					}
-					seterr = corebgp.SetTCPMD5Signature(fd,
-						remote, prefixLen, *md5)
+					seterr = corebgp.SetTCPMD5Signature(fd, remote, *md5)
 				})
 				if err != nil {
 					return err
@@ -61,7 +57,7 @@ func main() {
 		}
 	}
 	corebgp.SetLogger(log.Print)
-	srv, err := corebgp.NewServer(net.ParseIP(*routerID))
+	srv, err := corebgp.NewServer(netip.MustParseAddr(*routerID))
 	if err != nil {
 		log.Fatalf("error constructing server: %v", err)
 	}
@@ -73,12 +69,7 @@ func main() {
 				var seterr error
 				err := c.Control(func(fdPtr uintptr) {
 					fd := int(fdPtr)
-					prefixLen := uint8(32)
-					if remote.To4() == nil {
-						prefixLen = 128
-					}
-					seterr = corebgp.SetTCPMD5Signature(fd,
-						remote, prefixLen, *md5)
+					seterr = corebgp.SetTCPMD5Signature(fd, remote, *md5)
 				})
 				if err != nil {
 					return err
@@ -141,7 +132,7 @@ func (p *plugin) GetCapabilities(c corebgp.PeerConfig) []corebgp.Capability {
 	return caps
 }
 
-func (p *plugin) OnOpenMessage(peer corebgp.PeerConfig, routerID net.IP, capabilities []corebgp.Capability) *corebgp.Notification {
+func (p *plugin) OnOpenMessage(peer corebgp.PeerConfig, routerID netip.Addr, capabilities []corebgp.Capability) *corebgp.Notification {
 	log.Println("open message received")
 	return nil
 }

--- a/fsm.go
+++ b/fsm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strconv"
 	"sync"
 	"time"
@@ -616,10 +617,10 @@ func (f *fsm) openSent() (fsmState, error) {
 					return idleState, fmt.Errorf("error validating open message: %w", err)
 				}
 				f.remoteID = m.bgpID
-				rid := make([]byte, 4)
-				binary.BigEndian.PutUint32(rid, m.bgpID)
+				var rid [4]byte
+				binary.BigEndian.PutUint32(rid[:], m.bgpID)
 
-				n := f.peer.plugin.OnOpenMessage(f.peer.config, rid, m.getCapabilities())
+				n := f.peer.plugin.OnOpenMessage(f.peer.config, netip.AddrFrom4(rid), m.getCapabilities())
 				if n != nil {
 					f.sendNotification(n) // nolint: errcheck
 					return idleState, newNotificationError(n, true)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jwhited/corebgp
 
-go 1.15
+go 1.18
 
 require golang.org/x/sys v0.0.0-20210309074719-68d13333faf2

--- a/plugin.go
+++ b/plugin.go
@@ -1,6 +1,6 @@
 package corebgp
 
-import "net"
+import "net/netip"
 
 // Plugin is a BGP peer plugin.
 type Plugin interface {
@@ -16,7 +16,7 @@ type Plugin interface {
 	// Per RFC5492 a BGP speaker should only send a Notification if a required
 	// capability is missing; unknown or unsupported capabilities should be
 	// ignored.
-	OnOpenMessage(peer PeerConfig, routerID net.IP, capabilities []Capability) *Notification
+	OnOpenMessage(peer PeerConfig, routerID netip.Addr, capabilities []Capability) *Notification
 
 	// OnEstablished is fired when a peer's FSM transitions to the Established
 	// state. The returned UpdateMessageHandler will be fired when an Update

--- a/tcp_md5_sig.go
+++ b/tcp_md5_sig.go
@@ -1,4 +1,4 @@
-// +build !linux
+//go:build !linux
 
 package corebgp
 
@@ -13,7 +13,6 @@ import (
 // < 4.13.
 //
 // https://tools.ietf.org/html/rfc2385
-func SetTCPMD5Signature(fd int, address net.IP, prefixLen uint8,
-	key string) error {
+func SetTCPMD5Signature(fd int, address net.IP, prefixLen uint8, key string) error {
 	return errors.New("unsupported")
 }

--- a/tcp_md5_sig_linux_test.go
+++ b/tcp_md5_sig_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"syscall"
 	"testing"
 	"time"
@@ -34,8 +35,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	err = raw.Control(func(fdPtr uintptr) {
 		fd := int(fdPtr)
 		// nil address
-		seterr = SetTCPMD5Signature(fd, nil, 32,
-			"password")
+		seterr = SetTCPMD5Signature(fd, netip.Addr{}, "password")
 	})
 	if err != nil {
 		t.Fatalf("control err: %v", err)
@@ -48,8 +48,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	err = raw.Control(func(fdPtr uintptr) {
 		fd := int(fdPtr)
 		// ipv6 address
-		seterr = SetTCPMD5Signature(fd, net.ParseIP("2001:db8::1"),
-			128, "password")
+		seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("2001:db8::1"), "password")
 	})
 	if err != nil {
 		t.Fatalf("control err: %v", err)
@@ -62,8 +61,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	err = raw.Control(func(fdPtr uintptr) {
 		fd := int(fdPtr)
 		// valid
-		seterr = SetTCPMD5Signature(fd, net.ParseIP("127.0.0.1"),
-			32, "password")
+		seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("127.0.0.1"), "password")
 	})
 	if err != nil {
 		t.Fatalf("control err: %v", err)
@@ -73,8 +71,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	}
 
 	// dial w/password from previously set addr, this should succeed
-	laddr, err := net.ResolveTCPAddr("tcp",
-		net.JoinHostPort("127.0.0.1", "0"))
+	laddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("127.0.0.1", "0"))
 	if err != nil {
 		t.Fatalf("error resolving laddr: %v", err)
 	}
@@ -84,8 +81,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 		Control: func(network, address string, c syscall.RawConn) error {
 			err := c.Control(func(fdPtr uintptr) {
 				fd := int(fdPtr)
-				seterr = SetTCPMD5Signature(fd, net.ParseIP("127.0.0.1"),
-					32, "password")
+				seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("127.0.0.1"), "password")
 			})
 			if err != nil {
 				return err
@@ -93,8 +89,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 			return seterr
 		},
 	}
-	conn, err := dialer.Dial("tcp", fmt.Sprintf("127.0.0.1:%s",
-		port))
+	conn, err := dialer.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", port))
 	if err != nil {
 		t.Fatalf("error dialing w/md5: %v", err)
 	}
@@ -104,8 +99,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	err = raw.Control(func(fdPtr uintptr) {
 		fd := int(fdPtr)
 		// unset
-		seterr = SetTCPMD5Signature(fd, net.ParseIP("127.0.0.1"),
-			32, "")
+		seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("127.0.0.1"), "")
 	})
 	if err != nil {
 		t.Fatalf("control err: %v", err)
@@ -127,8 +121,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 		Control: func(network, address string, c syscall.RawConn) error {
 			err := c.Control(func(fdPtr uintptr) {
 				fd := int(fdPtr)
-				seterr = SetTCPMD5Signature(fd, net.ParseIP("127.0.0.1"),
-					32, "password")
+				seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("127.0.0.1"), "password")
 			})
 			if err != nil {
 				return err
@@ -136,8 +129,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 			return seterr
 		},
 	}
-	lis, err = lc.Listen(context.Background(), "tcp",
-		net.JoinHostPort("::", "0"))
+	lis, err = lc.Listen(context.Background(), "tcp", net.JoinHostPort("::", "0"))
 	if err != nil {
 		t.Fatalf("error listening: %v", err)
 	}
@@ -146,8 +138,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error splitting host/port: %v", err)
 	}
-	laddr, err = net.ResolveTCPAddr("tcp",
-		net.JoinHostPort("127.0.0.1", "0"))
+	laddr, err = net.ResolveTCPAddr("tcp", net.JoinHostPort("127.0.0.1", "0"))
 	if err != nil {
 		t.Fatalf("error resolving laddr: %v", err)
 	}
@@ -160,8 +151,7 @@ func TestSetTCPMD5Signature(t *testing.T) {
 		Control: func(network, address string, c syscall.RawConn) error {
 			err := c.Control(func(fdPtr uintptr) {
 				fd := int(fdPtr)
-				seterr = SetTCPMD5Signature(fd, net.ParseIP("127.0.0.1"),
-					32, "password")
+				seterr = SetTCPMD5Signature(fd, netip.MustParseAddr("127.0.0.1"), "password")
 			})
 			if err != nil {
 				return err

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.15
-ARG BIRD_VERSION=v2.0.7
+FROM golang:1.18
+ARG BIRD_VERSION=v2.0.8
 
 # utils & BIRD deps
 RUN apt-get update && \


### PR DESCRIPTION
Hello!

First, let me thank you for this great package :) It helped me a lot recently.

In Go 1.18 there will be a new netip package that contains a better implementation of IP addresses (originally at https://github.com/inetaf/netaddr , see https://github.com/golang/go/issues/46518 ). I've been using it for a while and for most workloads it's much better :) Conversion between netip.Addr and net.IP is possible and trivial, so anybody who wishes to keep using net.IP can do so without much hassle. I just think that we should default to netip.Addr, and use net.IP only where required (address manipulation at bit/byte level).

Go 1.18 will be out in February, so there is no rush :) But please let me know if you intend to merge this. Because if you do, I'd like to post more PRs, namely the fixes for the two issues you have here and then also some adjustments to the peer config struct (I'd like to separate the config and state, and include the peer state in plugin API).