### PR TITLE
Add large communities decoder and fix local pref attribute flag validation

### DIFF
--- a/example_update_decoder_test.go
+++ b/example_update_decoder_test.go
@@ -2,8 +2,9 @@ package corebgp_test
 
 import (
 	"fmt"
-	"github.com/jwhited/corebgp"
 	"net/netip"
+
+	"github.com/jwhited/corebgp"
 )
 
 type updateMessage struct {


### PR DESCRIPTION
I'm evaluating corebgp for use in a small project. When I last looked at this package maybe a year ago I noticed that it had no native ability to decode update messages so i resolved this by pulling in some functions/types from gobgp. Thank you for adding native decoding! For my use case I need to be able to decode large communities so this change adds that since it appears it was missing. Additionally I observed that the local preference decoder was not correctly validating attribute flags. Local pref is a well-known attribute which means the transitive flag must be set to 1 and all other flags are 0:

![image](https://github.com/jwhited/corebgp/assets/5504449/33d3c341-cc3e-479c-b77c-9b9ee48d3af2)


It looks like this was incorrectly set to expecting the optional flag as 1 (true) and transitive as 0 (false) so I fixed this and added some test cases.

Lastly, I added some simple changes to the example decoder to show how to decode/display MED, Local Pref and Large Communities.