### PR TITLE
allow non-global-unicast peer addresses

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -271,7 +271,7 @@ func (o *openMessage) validate(localID, localAS, remoteAS uint32) error {
 	var id [4]byte
 	binary.BigEndian.PutUint32(id[:], o.bgpID)
 	addr := netip.AddrFrom4(id)
-	if !addr.IsGlobalUnicast() {
+	if addr.IsMulticast() {
 		n := newNotification(NOTIF_CODE_OPEN_MESSAGE_ERR,
 			NOTIF_SUBCODE_BAD_BGP_ID, nil)
 		return newNotificationError(n, true)


### PR DESCRIPTION
Hi, thanks for the great project.

We are trying to use it to communicate with AWS Transit Gateway Connect Attachment. In short, communication with the attachment happens over GRE.

Inside of each tunnel, there are BGP sessions over `/29` ranges in `169.254`.
* Those are link-local IPv4 unicast ranges;
* Those are currently filtered out in corebgp: https://github.com/jwhited/corebgp/blob/f3f0a0ed16a9bcd94f145478eb02fcd3ea035925/packet.go#L274-L278
* There's currently no possibility to select other ranges in TGW Connect Peer configuration;

Proposal:
* Introduce a new configuration entry in `PeerConfig`;
* If this new flag is enabled, skip the relevant check;
* Open to implement a different approach, if you see a better one.

Update:
* Only exclude multicast addresses for this check