### PR TITLE
Avoid decoding errors when AS-PATH is empty (iBGP paths)

### DIFF
--- a/update.go
+++ b/update.go
@@ -309,6 +309,12 @@ func (a *ASPathAttr) Decode(flags PathAttrFlags, b []byte) error {
 	if err != nil {
 		return err
 	}
+
+	// empty AS-PATH
+	if len(b) == 0 {
+		return nil
+	}
+
 	if len(b) < 6 || len(b)%2 != 0 { // corebgp requires four octet AS
 		return &TreatAsWithdrawUpdateErr{
 			Code:         PATH_ATTR_AS_PATH,


### PR DESCRIPTION
When AS-PATH was empty (from iBGP paths originated in the network for example),
decoding would fail because of the len(b) < 6 check.

This adds a check for empty as-path beforehand, and returns immediately if the as-path is empty.