### PR TITLE
Fix decoding of AS-PATH for long-ish attr

### DIFF
--- a/update.go
+++ b/update.go
@@ -341,7 +341,8 @@ func (a *ASPathAttr) Decode(flags PathAttrFlags, b []byte) error {
 			}
 		}
 		segType := b[0]
-		segLen := int(b[1] * 4)
+		// cast length to int otherwise it wraps the uint8/byte
+		segLen := int(b[1]) * 4
 		if segLen == 0 {
 			return asPathMalformedErr()
 		}


### PR DESCRIPTION
The current implementation incurs counter wrap when the path is longer than an uint8.

I debugged using the following test-case, but I am not sure how to include it properly in the test-suite:
```
func TestASPathDecode(t *testing.T) {
	update := []byte{2, 72, 0, 0, 18, 29, 0, 0, 218, 13, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43, 0, 2, 82, 43}

	asPathAttr  := &ASPathAttr{}
	err := asPathAttr.Decode(PathAttrFlags(1<<6), update)
	if err != nil {
		t.Errorf("failed to decode: %s", err)
	}
}
```
