### PR TITLE
make logging thread safe

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,27 +1,28 @@
 package corebgp
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Logger is a log.Print-compatible function
 type Logger func(...interface{})
 
 var (
-	logger Logger = nil
+	defaultLogger Logger = nil
 )
 
-// SetLogger enables logging with the provided Logger.
+// SetDefaultLogger sets the default logger for all instances
+// of a corebgp server. Passing the WithLogger option to the server
+// constructor is preferred as this is function is maintained for
+// backwards compatibility.
 func SetLogger(l Logger) {
-	logger = l
+	defaultLogger = l
 }
 
-func log(v ...interface{}) {
-	if logger != nil {
-		logger(v...)
+func (l Logger) log(v ...interface{}) {
+	if l != nil {
+		l(v...)
 	}
 }
 
-func logf(format string, v ...interface{}) {
-	log(fmt.Sprintf(format, v...))
+func (l Logger) logf(format string, v ...interface{}) {
+	l.log(fmt.Sprintf(format, v...))
 }

--- a/peer.go
+++ b/peer.go
@@ -21,6 +21,7 @@ const (
 type peer struct {
 	config  PeerConfig
 	id      uint32
+	logger  Logger
 	plugin  Plugin
 	options peerOptions
 
@@ -45,10 +46,11 @@ const (
 	in  = 1
 )
 
-func newPeer(config PeerConfig, id uint32, plugin Plugin, options peerOptions) *peer {
+func newPeer(config PeerConfig, id uint32, logger Logger, plugin Plugin, options peerOptions) *peer {
 	p := &peer{
 		config:            config,
 		id:                id,
+		logger:            logger,
 		plugin:            plugin,
 		options:           options,
 		inConnCh:          make(chan net.Conn),
@@ -89,7 +91,7 @@ func other(i int) int {
 }
 
 func (p *peer) logTransition(i int, from, to fsmState) {
-	logf("[%s] FSM-%s transition %s => %s", p.config.RemoteAddress,
+	p.logger.logf("[%s] FSM-%s transition %s => %s", p.config.RemoteAddress,
 		direction(i), from, to)
 }
 
@@ -206,7 +208,7 @@ func direction(i int) string {
 
 // handleError handles an error during fsm operation
 func (p *peer) handleError(i int, err error) {
-	logf("[%s] FSM-%s %s error: %v",
+	p.logger.logf("[%s] FSM-%s %s error: %v",
 		p.config.RemoteAddress, direction(i), p.fsmState[i], err)
 	var nerr *notificationError
 	if errors.As(err, &nerr) {
@@ -240,7 +242,7 @@ func (p *peer) updateStartupDelay() {
 
 	p.startupDelayTimer.Stop()
 	p.startupDelayTimer = time.NewTimer(p.startupDelay)
-	logf("[%s] damping peer for %s", p.config.RemoteAddress, p.startupDelay)
+	p.logger.logf("[%s] damping peer for %s", p.config.RemoteAddress, p.startupDelay)
 }
 
 // main run loop
@@ -257,7 +259,7 @@ func (p *peer) run() {
 		case <-p.closeCh:
 			return
 		case <-p.startupDelayTimer.C:
-			logf("[%s] startup delay timer expired, enabling peer",
+			p.logger.logf("[%s] startup delay timer expired, enabling peer",
 				p.config.RemoteAddress)
 			p.enableFSM(out, nil)
 			p.inHoldDown = false

--- a/server.go
+++ b/server.go
@@ -11,9 +11,10 @@ import (
 
 // Server is a BGP server that manages peers.
 type Server struct {
-	mu    sync.Mutex
-	id    uint32
-	peers map[string]*peer
+	mu     sync.Mutex
+	id     uint32
+	logger Logger
+	peers  map[string]*peer
 
 	// control channels & run state
 	serving       bool
@@ -23,7 +24,7 @@ type Server struct {
 }
 
 // NewServer creates a new Server.
-func NewServer(routerID netip.Addr) (*Server, error) {
+func NewServer(routerID netip.Addr, options ...ServerOption) (*Server, error) {
 	if !routerID.Is4() {
 		return nil, errors.New("invalid router ID")
 	}
@@ -31,9 +32,13 @@ func NewServer(routerID netip.Addr) (*Server, error) {
 	s := &Server{
 		mu:            sync.Mutex{},
 		id:            binary.BigEndian.Uint32(routerID.AsSlice()),
+		logger:        defaultLogger,
 		peers:         make(map[string]*peer),
 		doneServingCh: make(chan struct{}),
 		closeCh:       make(chan struct{}),
+	}
+	for _, opt := range options {
+		opt(s)
 	}
 	return s, nil
 }
@@ -218,7 +223,7 @@ func (s *Server) AddPeer(config PeerConfig, plugin Plugin,
 	if exists {
 		return ErrPeerAlreadyExists
 	}
-	p := newPeer(config, s.id, plugin, o)
+	p := newPeer(config, s.id, s.logger, plugin, o)
 	if s.serving {
 		p.start()
 	}

--- a/server_options.go
+++ b/server_options.go
@@ -1,0 +1,11 @@
+package corebgp
+
+type ServerOption func(*Server)
+
+// WithLogger returns a ServerOption that sets the logger for the server.
+// This should be a log.Print-compatible function.
+func WithLogger(l Logger) ServerOption {
+	return func(s *Server) {
+		s.logger = l
+	}
+}


### PR DESCRIPTION
In the event you have two corebgp servers running in the same process, a data race can be created due to the logger being set as a package var:
```
WARNING: DATA RACE
Read at 0x0000011bb370 by goroutine 75:
  github.com/jwhited/corebgp.log()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/logger.go:20 +0xc0
  github.com/jwhited/corebgp.logf()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/logger.go:26 +0x34
  github.com/jwhited/corebgp.(*peer).logTransition()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/peer.go:92 +0x134
  github.com/jwhited/corebgp.(*peer).sendTransitionToFSM()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/peer.go:111 +0xec
  github.com/jwhited/corebgp.(*peer).handleStateTransition()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/peer.go:196 +0x338
  github.com/jwhited/corebgp.(*peer).run()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/peer.go:269 +0x2f8
  github.com/jwhited/corebgp.(*peer).start.gowrap1()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/peer.go:291 +0x34

Previous write at 0x0000011bb370 by goroutine 112:
  github.com/jwhited/corebgp.SetLogger()
      /go/pkg/mod/github.com/jwhited/corebgp@v0.8.5/logger.go:16 +0x3c
  github.com/malbeclabs/doublezero/client/doublezerod/internal/bgp.NewBgpServer()
      /workspaces/doublezero/client/doublezerod/internal/bgp/bgp.go:105 +0x30
  github.com/malbeclabs/doublezero/client/doublezerod/internal/runtime.Run()
      /workspaces/doublezero/client/doublezerod/internal/runtime/run.go:20 +0xe4
  github.com/malbeclabs/doublezero/client/doublezerod/internal/runtime_test.TestEndToEnd_IBRL.func2.10()
      /workspaces/doublezero/client/doublezerod/internal/runtime/run_test.go:391 +0x74
  ```

This PR creates a new `WithLogger` option for the corebgp server constructor that allows for a logger to be set on a instance basis. This is then passed down through the peer constructor as well. The `SetLogger` function has been kept to maintain backwards compatibility.